### PR TITLE
enable batching support in our servers

### DIFF
--- a/services/accounts/index.js
+++ b/services/accounts/index.js
@@ -75,6 +75,7 @@ async function startApolloServer(typeDefs, resolvers) {
         resolvers,
       },
     ]),
+    allowBatchedHttpRequests: true,
     plugins: [ApolloServerPluginDrainHttpServer({ httpServer })],
   });
 

--- a/services/inventory/index.js
+++ b/services/inventory/index.js
@@ -68,6 +68,7 @@ async function startApolloServer(typeDefs, resolvers) {
         resolvers,
       },
     ]),
+    allowBatchedHttpRequests: true,
     plugins: [ApolloServerPluginDrainHttpServer({ httpServer })],
   });
 

--- a/services/products/index.js
+++ b/services/products/index.js
@@ -82,6 +82,7 @@ async function startApolloServer(typeDefs, resolvers) {
         resolvers,
       },
     ]),
+    allowBatchedHttpRequests: true,
     plugins: [ApolloServerPluginDrainHttpServer({ httpServer })],
   });
 

--- a/services/reviews/index.js
+++ b/services/reviews/index.js
@@ -121,6 +121,7 @@ async function startApolloServer(typeDefs, resolvers) {
         resolvers,
       },
     ]),
+    allowBatchedHttpRequests: true,
     plugins: [ApolloServerPluginDrainHttpServer({ httpServer })],
   });
 


### PR DESCRIPTION
This is helpful when testing subgraph batching support in the router.